### PR TITLE
Fix TELEPHONY_SERVICE reference for RN 0.83 compat

### DIFF
--- a/android/src/main/java/com/samitha/timezone/TimezoneModule.kt
+++ b/android/src/main/java/com/samitha/timezone/TimezoneModule.kt
@@ -1,6 +1,7 @@
 package com.samitha.timezone
 
 import android.content.ContentResolver
+import android.content.Context
 import android.os.Build
 import android.provider.Settings
 import android.telephony.TelephonyManager
@@ -54,7 +55,7 @@ class TimezoneModule(reactContext: ReactApplicationContext) :
   @ReactMethod(isBlockingSynchronousMethod = true)
   override fun getRegionByTelephony(): String? {
     return try {
-      val telephonyService = reactApplicationContext.getSystemService(ReactApplicationContext.TELEPHONY_SERVICE) as? TelephonyManager
+      val telephonyService = reactApplicationContext.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
       telephonyService?.networkCountryIso
     } catch (e: Exception) {
       null


### PR DESCRIPTION
# React Native Timezone Pull Request

## Pull request type

Please check the change your PR introduces:

- [x] Bugfix
- [ ] New feature
- [ ] UI/UX update
- [ ] Unit test related changes
- [ ] Code quality improvements (Sonar, etc.)
- [ ] Refactoring (improving code structure without changing behaviour)
- [ ] Documentation related changes
- [ ] Security related changes
- [ ] Performance-related changes
- [ ] Other (please describe):

## Additional Information

This change is required, otherwise React Native 0.83.1 build fails with:
```
e: file://node_modules/react-native-timezone/android/src/main/java/com/samitha/timezone/TimezoneModule.kt:57:95 Unresolved reference 'TELEPHONY_SERVICE'.
```

## Checklist

To qualify for a review, your MR must fulfil the following requirements:

- [x] I have performed a self-review of my code
- [x] I have tested the changes locally
- [ ] I have ran unit tests locally and they have passed
- [ ] I have added comments where context is needed
- [ ] Unit/Integration/UI tests have been updated/added for my changes
- [ ] Build related tasks have been executed & passed
